### PR TITLE
feat(i18n): Add multilingual support to the plugin

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm run:*)",
+      "Bash(npx tsc:*)"
+    ]
+  }
+}

--- a/I18N_IMPLEMENTATION.md
+++ b/I18N_IMPLEMENTATION.md
@@ -1,0 +1,64 @@
+# 多语言支持实现总结
+
+## 已完成的工作
+
+### 1. 创建 i18n 文件夹和翻译文件
+- `src/i18n/en.ts` - 英文翻译
+- `src/i18n/zh.ts` - 中文翻译
+- `src/i18n/index.ts` - i18n 入口文件，包含语言检测和翻译获取功能
+
+### 2. 修改主插件文件 (main.ts)
+- 导入 i18n 模块
+- 添加 `t` (翻译对象) 和 `currentLocale` 属性
+- 添加 `initI18n()` 方法初始化多语言支持
+- 替换所有硬编码文本为翻译键
+- 传递翻译对象给模态框组件
+
+### 3. 修改设置选项卡 (SettingTab.ts)
+- 接收并使用翻译对象
+- 替换所有设置界面文本为翻译键
+
+### 4. 修改模态框组件
+- `AddPropModal.ts` - 接收并传递翻译对象
+- `AddConfirmModal.ts` - 接收并传递翻译对象
+- `RemoveModal.ts` - 接收并传递翻译对象
+- `RemoveConfirmModal.ts` - 接收并传递翻译对象
+
+### 5. 修改 Svelte 组件
+- `AddPropForm.svelte` - 使用翻译对象，替换所有界面文本
+- `RemovePropForm.svelte` - 使用翻译对象，替换所有界面文本
+- `AddConfirmForm.svelte` - 使用翻译对象，替换所有界面文本
+- `RemoveConfirmForm.svelte` - 使用翻译对象，替换所有界面文本
+
+## 功能特性
+
+1. **自动语言检测**
+   - 优先使用 Obsidian 的语言设置
+   - 其次使用浏览器语言
+   - 默认回退到英文
+
+2. **支持的语言**
+   - 英语 (en, en-US, en-GB, en-CA, en-AU)
+   - 中文 (zh, zh-CN, zh-TW, zh-HK, zh-SG)
+
+3. **格式化支持**
+   - 支持带参数的翻译字符串
+   - 例如：`"Added props to {count}/{total} files"`
+
+## 使用方式
+
+插件会自动根据用户的语言设置显示相应的语言，无需额外配置。
+
+## 翻译文件结构
+
+翻译文件包含以下类别：
+- Commands - 命令名称
+- Menu items - 菜单项
+- Notices - 通知消息
+- Settings - 设置界面
+- AddPropForm - 添加属性表单
+- RemovePropForm - 移除属性表单
+- AddConfirmForm - 添加确认表单
+- RemoveConfirmForm - 移除确认表单
+- Status bar - 状态栏
+- Common - 通用文本

--- a/package-lock.json
+++ b/package-lock.json
@@ -902,9 +902,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.53.3.tgz",
-      "integrity": "sha512-mRSi+4cBjrRLoaal2PnqH82Wqyb+d3HsPUN/W+WslCXsZsyHa9ZeQQX/pQsZaVIWDkPcpV6jJ+3KLbTbgnwv8w==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
       "cpu": [
         "arm"
       ],
@@ -916,9 +916,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.53.3.tgz",
-      "integrity": "sha512-CbDGaMpdE9sh7sCmTrTUyllhrg65t6SwhjlMJsLr+J8YjFuPmCEjbBSx4Z/e4SmDyH3aB5hGaJUP2ltV/vcs4w==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
       "cpu": [
         "arm64"
       ],
@@ -930,9 +930,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.53.3.tgz",
-      "integrity": "sha512-Nr7SlQeqIBpOV6BHHGZgYBuSdanCXuw09hon14MGOLGmXAFYjx1wNvquVPmpZnl0tLjg25dEdr4IQ6GgyToCUA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
       "cpu": [
         "arm64"
       ],
@@ -944,9 +944,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.53.3.tgz",
-      "integrity": "sha512-DZ8N4CSNfl965CmPktJ8oBnfYr3F8dTTNBQkRlffnUarJ2ohudQD17sZBa097J8xhQ26AwhHJ5mvUyQW8ddTsQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
       "cpu": [
         "x64"
       ],
@@ -958,9 +958,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.53.3.tgz",
-      "integrity": "sha512-yMTrCrK92aGyi7GuDNtGn2sNW+Gdb4vErx4t3Gv/Tr+1zRb8ax4z8GWVRfr3Jw8zJWvpGHNpss3vVlbF58DZ4w==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
       "cpu": [
         "arm64"
       ],
@@ -972,9 +972,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.53.3.tgz",
-      "integrity": "sha512-lMfF8X7QhdQzseM6XaX0vbno2m3hlyZFhwcndRMw8fbAGUGL3WFMBdK0hbUBIUYcEcMhVLr1SIamDeuLBnXS+Q==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
       "cpu": [
         "x64"
       ],
@@ -986,9 +986,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.53.3.tgz",
-      "integrity": "sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
       "cpu": [
         "arm"
       ],
@@ -1000,9 +1000,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.53.3.tgz",
-      "integrity": "sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
       "cpu": [
         "arm"
       ],
@@ -1014,9 +1014,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.53.3.tgz",
-      "integrity": "sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
       "cpu": [
         "arm64"
       ],
@@ -1028,9 +1028,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.53.3.tgz",
-      "integrity": "sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
       "cpu": [
         "arm64"
       ],
@@ -1042,9 +1042,23 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.53.3.tgz",
-      "integrity": "sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
       "cpu": [
         "loong64"
       ],
@@ -1056,9 +1070,23 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.53.3.tgz",
-      "integrity": "sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
       "cpu": [
         "ppc64"
       ],
@@ -1070,9 +1098,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.53.3.tgz",
-      "integrity": "sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
       "cpu": [
         "riscv64"
       ],
@@ -1084,9 +1112,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.53.3.tgz",
-      "integrity": "sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
       "cpu": [
         "riscv64"
       ],
@@ -1098,9 +1126,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.53.3.tgz",
-      "integrity": "sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
       "cpu": [
         "s390x"
       ],
@@ -1112,9 +1140,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.53.3.tgz",
-      "integrity": "sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
       "cpu": [
         "x64"
       ],
@@ -1126,9 +1154,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.53.3.tgz",
-      "integrity": "sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
       "cpu": [
         "x64"
       ],
@@ -1139,10 +1167,24 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.53.3.tgz",
-      "integrity": "sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
       "cpu": [
         "arm64"
       ],
@@ -1154,9 +1196,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.53.3.tgz",
-      "integrity": "sha512-GOFuKpsxR/whszbF/bzydebLiXIHSgsEUp6M0JI8dWvi+fFa1TD6YQa4aSZHtpmh2/uAlj/Dy+nmby3TJ3pkTw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
       "cpu": [
         "arm64"
       ],
@@ -1168,9 +1210,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.53.3.tgz",
-      "integrity": "sha512-iah+THLcBJdpfZ1TstDFbKNznlzoxa8fmnFYK4V67HvmuNYkVdAywJSoteUszvBQ9/HqN2+9AZghbajMsFT+oA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
       "cpu": [
         "ia32"
       ],
@@ -1182,9 +1224,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.53.3.tgz",
-      "integrity": "sha512-J9QDiOIZlZLdcot5NXEepDkstocktoVjkaKUtqzgzpt2yWjGlbYiKyp05rWwk4nypbYUNoFAztEgixoLaSETkg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
       "cpu": [
         "x64"
       ],
@@ -1196,9 +1238,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.53.3.tgz",
-      "integrity": "sha512-UhTd8u31dXadv0MopwGgNOBpUVROFKWVQgAg5N1ESyCz8AuBcMqm4AuTjrwgQKGDfoFuz02EuMRHQIw/frmYKQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
       "cpu": [
         "x64"
       ],
@@ -1492,6 +1534,13 @@
       "dependencies": {
         "@types/estree": "*"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
@@ -1867,10 +1916,11 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2305,9 +2355,9 @@
       }
     },
     "node_modules/devalue": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.2.tgz",
-      "integrity": "sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.3.tgz",
+      "integrity": "sha512-nc7XjUU/2Lb+SvEFVGcWLiKkzfw8+qHI7zn8WYXKkLMgfGSHbgCEaR6bJpev8Cm6Rmrb19Gfd/tZvGqx9is3wg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2634,9 +2684,9 @@
       }
     },
     "node_modules/esrap": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.1.tgz",
-      "integrity": "sha512-GiYWG34AN/4CUyaWAgunGt0Rxvr1PTMlGC0vvEov/uOQYWne2bpN03Um+k8jT+q3op33mKouP2zeJ6OlM+qeUg==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.3.tgz",
+      "integrity": "sha512-8fOS+GIGCQZl/ZIlhl59htOlms6U8NvX6ZYgYHpRU/b6tVSh3uHkOHZikl3D4cMbYM0JlpBe+p/BkZEi8J9XIQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3586,10 +3636,11 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -4085,9 +4136,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.3.tgz",
-      "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4101,28 +4152,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.53.3",
-        "@rollup/rollup-android-arm64": "4.53.3",
-        "@rollup/rollup-darwin-arm64": "4.53.3",
-        "@rollup/rollup-darwin-x64": "4.53.3",
-        "@rollup/rollup-freebsd-arm64": "4.53.3",
-        "@rollup/rollup-freebsd-x64": "4.53.3",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.53.3",
-        "@rollup/rollup-linux-arm-musleabihf": "4.53.3",
-        "@rollup/rollup-linux-arm64-gnu": "4.53.3",
-        "@rollup/rollup-linux-arm64-musl": "4.53.3",
-        "@rollup/rollup-linux-loong64-gnu": "4.53.3",
-        "@rollup/rollup-linux-ppc64-gnu": "4.53.3",
-        "@rollup/rollup-linux-riscv64-gnu": "4.53.3",
-        "@rollup/rollup-linux-riscv64-musl": "4.53.3",
-        "@rollup/rollup-linux-s390x-gnu": "4.53.3",
-        "@rollup/rollup-linux-x64-gnu": "4.53.3",
-        "@rollup/rollup-linux-x64-musl": "4.53.3",
-        "@rollup/rollup-openharmony-arm64": "4.53.3",
-        "@rollup/rollup-win32-arm64-msvc": "4.53.3",
-        "@rollup/rollup-win32-ia32-msvc": "4.53.3",
-        "@rollup/rollup-win32-x64-gnu": "4.53.3",
-        "@rollup/rollup-win32-x64-msvc": "4.53.3",
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
         "fsevents": "~2.3.2"
       }
     },
@@ -4494,9 +4548,9 @@
       }
     },
     "node_modules/svelte": {
-      "version": "5.46.4",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.46.4.tgz",
-      "integrity": "sha512-VJwdXrmv9L8L7ZasJeWcCjoIuMRVbhuxbss0fpVnR8yorMmjNDwcjIH08vS6wmSzzzgAG5CADQ1JuXPS2nwt9w==",
+      "version": "5.53.6",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.53.6.tgz",
+      "integrity": "sha512-lP5DGF3oDDI9fhHcSpaBiJEkFLuS16h92DhM1L5K1lFm0WjOmUh1i2sNkBBk8rkxJRpob0dBE75jRfUzGZUOGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4504,13 +4558,14 @@
         "@jridgewell/sourcemap-codec": "^1.5.0",
         "@sveltejs/acorn-typescript": "^1.0.5",
         "@types/estree": "^1.0.5",
+        "@types/trusted-types": "^2.0.7",
         "acorn": "^8.12.1",
-        "aria-query": "^5.3.1",
+        "aria-query": "5.3.1",
         "axobject-query": "^4.1.0",
         "clsx": "^2.1.1",
-        "devalue": "^5.6.2",
+        "devalue": "^5.6.3",
         "esm-env": "^1.2.1",
-        "esrap": "^2.2.1",
+        "esrap": "^2.2.2",
         "is-reference": "^3.0.3",
         "locate-character": "^3.0.0",
         "magic-string": "^0.30.11",
@@ -4574,6 +4629,16 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/svelte/node_modules/aria-query": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
+      "integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/symbol-tree": {

--- a/src/AddConfirmForm.svelte
+++ b/src/AddConfirmForm.svelte
@@ -2,15 +2,17 @@
   import { onMount } from "svelte";
   import type { NewPropData } from "./main";
   import type { MultiPropSettings } from "./SettingTab";
+  import type en from "./i18n/en";
 
   interface Props {
     newProps: Map<string, NewPropData>;
     alterProp: MultiPropSettings["alterProp"];
     submission: () => void;
     cancel: () => void;
+    t: typeof en;
   }
 
-  let { newProps, alterProp, submission, cancel }: Props = $props();
+  let { newProps, alterProp, submission, cancel, t }: Props = $props();
 
   let btnCancel: HTMLButtonElement | null = $state(null);
 
@@ -19,11 +21,11 @@
   function createPropMsg(value: MultiPropSettings["alterProp"]) {
     switch (value) {
       case "ignore":
-        return "Any of these text props on existing notes will not be affected.";
+        return t.ignoreMsg;
       case "append":
-        return "NOTE: Any pre-existing text props will have their values be appended to.";
+        return t.appendMsg;
       case "overwrite":
-        return "WARNING: Any pre-existing text props will have their values overwritten.";
+        return t.overwriteMsg;
     }
   }
 
@@ -41,7 +43,7 @@
 <div>
   <form onsubmit={onSubmit}>
     <p class="msg">{msg}</p>
-    <p>The following props will be added:</p>
+    <p>{t.followingPropsWillBeAdded}</p>
     <ul>
       {#each [...newProps] as [propName, prop]}
         <li>
@@ -49,9 +51,9 @@
         </li>
       {/each}
     </ul>
-    <p>Are you sure you wish to proceed?</p>
-    <button class="mod-warning" type="submit">Confirm</button>
-    <button type="button" onclick={cancel} bind:this={btnCancel}>Cancel</button>
+    <p>{t.areYouSure}</p>
+    <button class="mod-warning" type="submit">{t.confirmButton}</button>
+    <button type="button" onclick={cancel} bind:this={btnCancel}>{t.cancelButton}</button>
   </form>
 </div>
 

--- a/src/AddConfirmModal.ts
+++ b/src/AddConfirmModal.ts
@@ -5,6 +5,7 @@ import { mount } from "svelte";
 import AddConfirmForm from "./AddConfirmForm.svelte";
 import type { NewPropData } from "./main";
 import type { MultiPropSettings } from "./SettingTab";
+import type en from "./i18n/en";
 
 /** Loads a modal and handles form submissions. */
 export class AddConfirmModal extends Modal {
@@ -12,17 +13,20 @@ export class AddConfirmModal extends Modal {
   submission: () => Promise<void>;
   alterProp: MultiPropSettings["alterProp"];
   component: any;
+  t: typeof en;
 
   constructor(
     app: App,
     props: Map<string, NewPropData>,
     alterProp: MultiPropSettings["alterProp"],
-    submission: () => Promise<void>
+    submission: () => Promise<void>,
+    t: typeof en
   ) {
     super(app);
     this.props = props;
     this.alterProp = alterProp;
     this.submission = submission;
+    this.t = t;
   }
   onSubmit() {
     this.submission();
@@ -34,7 +38,7 @@ export class AddConfirmModal extends Modal {
   }
 
   onOpen(): void {
-    this.titleEl.createEl("h2", { text: "Add Properties" });
+    this.titleEl.createEl("h2", { text: this.t.addPropertiesTitle });
 
     this.component = mount(AddConfirmForm, {
       target: this.contentEl,
@@ -43,6 +47,7 @@ export class AddConfirmModal extends Modal {
         alterProp: this.alterProp,
         submission: this.onSubmit.bind(this),
         cancel: this.onCancel.bind(this),
+        t: this.t,
       },
     });
   }

--- a/src/AddPropForm.svelte
+++ b/src/AddPropForm.svelte
@@ -5,6 +5,8 @@
   import { cleanTags, parseValue, removeExtraCommas } from "./helpers";
   import type { Property, PropertyTypes } from "./types/custom";
   import type { MultiPropSettings } from "./SettingTab";
+  import type en from "./i18n/en";
+  import { format } from "./i18n";
 
   interface Props {
     submission: (props: Map<string, NewPropData>) => void;
@@ -13,6 +15,7 @@
     defaultProps: { name: string; value: any; type: PropertyTypes }[];
     changeSetting: (setting: MultiPropSettings["alterProp"]) => void;
     suggestedProps: Property[];
+    t: typeof en;
   }
 
   let {
@@ -22,6 +25,7 @@
     defaultProps,
     changeSetting,
     suggestedProps,
+    t,
   }: Props = $props();
 
   let countInputs = 0; //Could replace with UUID.
@@ -105,7 +109,7 @@
     e.preventDefault();
     //Make sure there are no duplicate names.
     if (checkDuplicateNames()) {
-      runError("Duplicate property names are not allowed.");
+      runError(t.duplicateNamesError);
       return;
     }
 
@@ -182,11 +186,11 @@
 
 <div id="multi-properties-modal" class="modal-content">
   <div id="alert-container" class="alert-container hidden" bind:this={errorEl}>
-    <div>ERROR</div>
+    <div>{t.errorLabel}</div>
     <div id="alert-text">{alertText}</div>
   </div>
 
-  <p>Select from existing properties or create new ones:</p>
+  <p>{t.selectFromExistingOrCreate}</p>
   <div class="suggested-props">
     {#each suggestedProps as prop}
       <button
@@ -200,25 +204,23 @@
   </div>
 
   <p>
-    Type in a property name, then value. Use the dropbox to choose what type of
-    data you wish to store.
+    {t.typePropertyNameAndValue}
   </p>
   <p>
-    If you want to make a List property, use the Text data type and separate
-    each value with a "{delimiter}".
+    {format(t.makeListPropertyNote, { delimiter })}
   </p>
-  <p>If you want to add Tags, use the name "tags".</p>
+  <p>{t.addTagsNote}</p>
   <form onsubmit={onSubmit} bind:this={formEl}>
     <label>
-      {"How to alter props that already exist on notes."}
+      {t.howToAlterPropsLabel}
       <select
         id="alter-prop-select"
         bind:value={alterProp}
         onchange={() => onDropdownChange(alterProp)}
       >
-        <option value="ignore">Ignore the prop entirely.</option>
-        <option value="overwrite">Overwrite new value over prop.</option>
-        <option value="append">Append new value to prop.</option>
+        <option value="ignore">{t.ignoreOption}</option>
+        <option value="overwrite">{t.overwriteOption}</option>
+        <option value="append">{t.appendOption}</option>
       </select>
     </label>
     <div class="modal-inputs-container">
@@ -237,11 +239,11 @@
       <button
         type="button"
         onclick={() => addInputs([{ type: "text", name: "", value: "" }])}
-        class="a-btn">Add</button
+        class="a-btn">{t.addButton}</button
       >
     </div>
     <div class="modal-button-container">
-      <button type="submit" class="btn-submit">Submit</button>
+      <button type="submit" class="btn-submit">{t.submitButton}</button>
     </div>
   </form>
 </div>

--- a/src/AddPropModal.ts
+++ b/src/AddPropModal.ts
@@ -5,6 +5,7 @@ import type { NewPropData } from "./main";
 import { AddConfirmModal } from "./AddConfirmModal";
 import type { Property, PropertyTypes } from "./types/custom";
 import type { MultiPropSettings } from "./SettingTab";
+import type en from "./i18n/en";
 
 /** Loads a modal and handles form submissions. */
 export class PropModal extends Modal {
@@ -16,6 +17,7 @@ export class PropModal extends Modal {
   changeSetting: (value: MultiPropSettings["alterProp"]) => void;
   component: any;
   suggestedProps: Property[];
+  t: typeof en;
 
   constructor(
     app: App,
@@ -24,7 +26,8 @@ export class PropModal extends Modal {
     delimiter: string,
     defaultProps: { name: string; value: any; type: PropertyTypes }[],
     changeSetting: (value: MultiPropSettings["alterProp"]) => void,
-    suggestedProps: Property[]
+    suggestedProps: Property[],
+    t: typeof en
   ) {
     super(app);
     this.submission = submission;
@@ -33,6 +36,7 @@ export class PropModal extends Modal {
     this.defaultProps = defaultProps;
     this.changeSetting = changeSetting;
     this.suggestedProps = suggestedProps;
+    this.t = t;
   }
 
   //Run form submission if user clicks confirm.
@@ -53,12 +57,13 @@ export class PropModal extends Modal {
       this.app,
       this.props,
       this.alterProp,
-      this.onConfirm.bind(this)
+      this.onConfirm.bind(this),
+      this.t
     ).open();
   }
 
   onOpen(): void {
-    this.titleEl.createEl("h2", { text: "Add Properties" });
+    this.titleEl.createEl("h2", { text: this.t.addPropertiesTitle });
 
     this.component = mount(PropForm, {
       target: this.contentEl,
@@ -69,6 +74,7 @@ export class PropModal extends Modal {
         defaultProps: this.defaultProps,
         changeSetting: this.updateSetting.bind(this),
         suggestedProps: this.suggestedProps,
+        t: this.t,
       },
     });
   }

--- a/src/RemoveConfirmForm.svelte
+++ b/src/RemoveConfirmForm.svelte
@@ -1,17 +1,20 @@
 <script lang="ts">
   import { onMount } from "svelte";
+  import type en from "./i18n/en";
+  import { format } from "./i18n";
 
   interface Props {
     names?: string[];
     submission: () => void;
     cancel: () => void;
+    t: typeof en;
   }
 
-  let { names = ["test", "test2"], submission, cancel }: Props = $props();
+  let { names = ["test", "test2"], submission, cancel, t }: Props = $props();
 
   let btnCancel: HTMLButtonElement | null = $state(null);
 
-  let word = $derived(names.length > 1 ? "properties" : "property");
+  let word = $derived(names.length > 1 ? t.properties : t.property);
 
   function onSubmit(e: SubmitEvent) {
     e.preventDefault();
@@ -26,7 +29,7 @@
 
 <div>
   <form onsubmit={onSubmit}>
-    <p>The following {word} will be removed:</p>
+    <p>{format(t.followingPropertiesWillBeRemoved, { word })}</p>
     <ul>
       {#each names as name}
         <li>
@@ -34,8 +37,8 @@
         </li>
       {/each}
     </ul>
-    <p>Are you sure you wish to proceed?</p>
-    <button class="mod-warning" type="submit">Delete</button>
-    <button type="button" onclick={cancel} bind:this={btnCancel}>Cancel</button>
+    <p>{t.areYouSure}</p>
+    <button class="mod-warning" type="submit">{t.deleteButton}</button>
+    <button type="button" onclick={cancel} bind:this={btnCancel}>{t.cancelButton}</button>
   </form>
 </div>

--- a/src/RemoveConfirmModal.ts
+++ b/src/RemoveConfirmModal.ts
@@ -3,17 +3,20 @@
 import { Modal, App, Notice } from "obsidian";
 import { mount } from "svelte";
 import RemoveConfirmForm from "./RemoveConfirmForm.svelte";
+import type en from "./i18n/en";
 
 /** Loads a modal and handles form submissions. */
 export class RemoveConfirmModal extends Modal {
   names: string[];
   submission: () => Promise<void>;
   component: any;
+  t: typeof en;
 
-  constructor(app: App, names: string[], submission: () => Promise<void>) {
+  constructor(app: App, names: string[], submission: () => Promise<void>, t: typeof en) {
     super(app);
     this.names = names;
     this.submission = submission;
+    this.t = t;
   }
 
   onSubmit() {
@@ -28,10 +31,10 @@ export class RemoveConfirmModal extends Modal {
   onOpen(): void {
     //Prevent modal from opening if no names are passed.
     if (!this.names || this.names.length === 0) {
-      new Notice("Please check at least one property to remove.");
+      new Notice(this.t.pleaseCheckAtLeastOne);
       this.close();
     }
-    this.titleEl.createEl("h2", { text: "Remove Properties" });
+    this.titleEl.createEl("h2", { text: this.t.removePropertiesTitle });
 
     this.component = mount(RemoveConfirmForm, {
       target: this.contentEl,
@@ -39,6 +42,7 @@ export class RemoveConfirmModal extends Modal {
         names: this.names,
         submission: this.onSubmit.bind(this),
         cancel: this.onCancel.bind(this),
+        t: this.t,
       },
     });
   }

--- a/src/RemoveModal.ts
+++ b/src/RemoveModal.ts
@@ -4,6 +4,7 @@ import { Modal, App, Notice } from "obsidian";
 import { mount } from "svelte";
 import RemovePropForm from "./RemovePropForm.svelte";
 import { RemoveConfirmModal } from "./RemoveConfirmModal";
+import type en from "./i18n/en";
 
 /** Loads a modal and handles form submissions. */
 export class RemoveModal extends Modal {
@@ -11,19 +12,22 @@ export class RemoveModal extends Modal {
   props: string[];
   submission: (customProps: string[]) => Promise<void>;
   component: any;
+  t: typeof en;
 
   constructor(
     app: App,
     names: string[],
-    submission: (customProps: string[]) => Promise<void>
+    submission: (customProps: string[]) => Promise<void>,
+    t: typeof en
   ) {
     if (!names || names.length === 0) {
-      new Notice("No properties to remove");
+      new Notice(t.noPropertiesToRemove);
       return;
     }
     super(app);
     this.names = names;
     this.submission = submission;
+    this.t = t;
   }
 
   onConfirm() {
@@ -36,18 +40,20 @@ export class RemoveModal extends Modal {
     new RemoveConfirmModal(
       this.app,
       this.props,
-      this.onConfirm.bind(this)
+      this.onConfirm.bind(this),
+      this.t
     ).open();
   }
 
   onOpen(): void {
-    this.titleEl.createEl("h2", { text: "Remove Properties" });
+    this.titleEl.createEl("h2", { text: this.t.removePropertiesTitle });
 
     this.component = mount(RemovePropForm, {
       target: this.contentEl,
       props: {
         names: this.names,
         submission: this.onSubmit.bind(this),
+        t: this.t,
       },
     });
   }

--- a/src/RemovePropForm.svelte
+++ b/src/RemovePropForm.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
+  import type en from "./i18n/en";
+
   interface Props {
     names?: string[];
     submission: (props: string[]) => void;
+    t: typeof en;
   }
 
-  let { names = [], submission }: Props = $props();
+  let { names = [], submission, t }: Props = $props();
 
   let errorEl: HTMLDivElement | null = $state(null);
   let alertText = $state(".");
@@ -36,7 +39,7 @@
     e.preventDefault();
 
     if (checkCount === 0) {
-      alertText = "Please select at least one property to remove.";
+      alertText = t.selectAtLeastOneError;
       errorEl?.classList.remove("hidden");
       return;
     }
@@ -49,10 +52,10 @@
 
 <div>
   <div id="alert-container" class="alert-container hidden" bind:this={errorEl}>
-    <div>ERROR</div>
+    <div>{t.errorLabel}</div>
     <div id="alert-text">{alertText}</div>
   </div>
-  <p>Select the properties you wish to remove from the file selection.</p>
+  <p>{t.selectPropertiesToRemove}</p>
   <form onsubmit={onSubmit}>
     <div class="name-container">
       {#each inputs as input (input.name)}
@@ -67,9 +70,9 @@
       {/each}
     </div>
     <div class="button-container">
-      <button type="submit">Confirm</button>
+      <button type="submit">{t.confirmButton}</button>
       <button type="button" onclick={toggleAll}
-        >{isMaxChecked ? "Uncheck All" : "Check All"}</button
+        >{isMaxChecked ? t.uncheckAllButton : t.checkAllButton}</button
       >
     </div>
   </form>

--- a/src/SettingTab.ts
+++ b/src/SettingTab.ts
@@ -1,13 +1,16 @@
 import { PluginSettingTab, App, Setting, Notice } from "obsidian";
 
 import MultiPropPlugin from "./main";
+import type en from "./i18n/en";
 
 export class SettingTab extends PluginSettingTab {
   plugin: MultiPropPlugin;
+  t: typeof en;
 
   constructor(app: App, plugin: MultiPropPlugin) {
     super(app, plugin);
     this.plugin = plugin;
+    this.t = plugin.t;
   }
 
   display() {
@@ -15,15 +18,13 @@ export class SettingTab extends PluginSettingTab {
     containerEl.empty();
 
     new Setting(containerEl)
-      .setName("How to alter existing properties.")
-      .setDesc(
-        "Determine what to do when a property with the same name already exists in a file.  Note that incompatible types cannot be appended.(adding a number to a date)"
-      )
+      .setName(this.t.alterPropName)
+      .setDesc(this.t.alterPropDesc)
       .addDropdown((dropdown) => {
         dropdown
-          .addOption("overwrite", "Overwrite prop")
-          .addOption("append", "Append to prop")
-          .addOption("ignore", "Ignore prop")
+          .addOption("overwrite", this.t.overwriteProp)
+          .addOption("append", this.t.appendToProp)
+          .addOption("ignore", this.t.ignoreProp)
           .setValue(this.plugin.settings.alterProp)
           .onChange(async (value: "overwrite" | "append" | "ignore") => {
             this.plugin.settings.alterProp = value;
@@ -32,10 +33,8 @@ export class SettingTab extends PluginSettingTab {
       });
 
     new Setting(containerEl)
-      .setName("Recursive Iteration")
-      .setDesc(
-        "When toggled on, while looping through all files in a folder, you will also loop through any sub-folders."
-      )
+      .setName(this.t.recursiveName)
+      .setDesc(this.t.recursiveDesc)
       .addToggle((toggle) => {
         toggle.setValue(this.plugin.settings.recursive);
         toggle.onChange(async (value) => {
@@ -45,16 +44,14 @@ export class SettingTab extends PluginSettingTab {
       });
 
     new Setting(containerEl)
-      .setName("List Delimiter")
-      .setDesc(
-        "Set delimiter to use when creating a list.  Commas(,) are used by default."
-      )
+      .setName(this.t.listDelimiterName)
+      .setDesc(this.t.listDelimiterDesc)
       .addText((text) => {
         text.setValue(this.plugin.settings.delimiter);
         text.onChange(async (value: MultiPropSettings["alterProp"]) => {
           if (value.length > 1) {
             text.setValue(value[0]);
-            new Notice("Delimiter must be a single character.");
+            new Notice(this.t.delimiterMustBeSingleChar);
             return;
           }
           this.plugin.settings.delimiter = value;
@@ -63,10 +60,8 @@ export class SettingTab extends PluginSettingTab {
       });
 
     new Setting(containerEl)
-      .setName("Default Props File")
-      .setDesc(
-        "Select a file with properties that you want to load into the Multi Properties form by default.  Type in the full path of the desired file.(ex. Templates/PropFile 1)"
-      )
+      .setName(this.t.defaultPropsFileName)
+      .setDesc(this.t.defaultPropsFileDesc)
       .addText((text) => {
         text.setValue(this.plugin.settings.defaultPropPath);
         text.onChange(async (value) => {

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -1,0 +1,89 @@
+// English translations
+export default {
+  // Commands
+  addPropsToCurrentNote: "Add props to current note",
+  removePropsFromCurrentNote: "Remove props from current note",
+  addPropsToTabGroup: "Add props to tabs in active tab group",
+  removePropsFromTabGroup: "Remove props from tabs in active tab group",
+
+  // Menu items
+  addPropsToFile: "Add props to file.",
+  addPropsToFolder: "Add props to folder.",
+  removePropsFromFile: "Remove props from file.",
+  removePropsFromFolder: "Remove props from folder.",
+  addPropsFromAllTabs: "Add props from all tabs",
+  removePropsFromAllTabs: "Remove props from all tabs",
+  addPropsToSelectedFiles: "Add props to selected files",
+  removePropsFromSelectedFiles: "Remove props from selected files",
+  addPropsToSearchResults: "Add props to search results",
+  removePropsFromSearchResults: "Remove props from search results",
+
+  // Notices
+  noActiveFileToAdd: "No active file to add properties to.",
+  noActiveFileToRemove: "No active file to remove properties from.",
+  noOpenTabsToAdd: "No open tabs in the active tab group to add properties to.",
+  noOpenTabsToRemove: "No open tabs in the active tab group to remove properties from.",
+  noFilesToAdd: "No files to add properties to.",
+  noFilesToRemove: "No files to remove properties from.",
+  noPropertiesToRemove: "No properties to remove",
+  notValidPropsTemplate: "Not a valid Props template.",
+  checkDefaultPropsPath: "Check if you entered a valid path in the Default Props File setting.",
+  delimiterMustBeSingleChar: "Delimiter must be a single character.",
+
+  // Settings
+  settingsTitle: "Multi Properties Settings",
+  alterPropName: "How to alter existing properties.",
+  alterPropDesc: "Determine what to do when a property with the same name already exists in a file. Note that incompatible types cannot be appended (adding a number to a date).",
+  overwriteProp: "Overwrite prop",
+  appendToProp: "Append to prop",
+  ignoreProp: "Ignore prop",
+  recursiveName: "Recursive Iteration",
+  recursiveDesc: "When toggled on, while looping through all files in a folder, you will also loop through any sub-folders.",
+  listDelimiterName: "List Delimiter",
+  listDelimiterDesc: "Set delimiter to use when creating a list. Commas(,) are used by default.",
+  defaultPropsFileName: "Default Props File",
+  defaultPropsFileDesc: "Select a file with properties that you want to load into the Multi Properties form by default. Type in the full path of the desired file (ex. Templates/PropFile 1).",
+
+  // AddPropForm
+  selectFromExistingOrCreate: "Select from existing properties or create new ones:",
+  typePropertyNameAndValue: "Type in a property name, then value. Use the dropbox to choose what type of data you wish to store.",
+  makeListPropertyNote: "If you want to make a List property, use the Text data type and separate each value with a \"{delimiter}\".",
+  addTagsNote: "If you want to add Tags, use the name \"tags\".",
+  howToAlterPropsLabel: "How to alter props that already exist on notes.",
+  ignoreOption: "Ignore the prop entirely.",
+  overwriteOption: "Overwrite new value over prop.",
+  appendOption: "Append new value to prop.",
+  addButton: "Add",
+  submitButton: "Submit",
+  duplicateNamesError: "Duplicate property names are not allowed.",
+  errorLabel: "ERROR",
+
+  // RemovePropForm
+  selectPropertiesToRemove: "Select the properties you wish to remove from the file selection.",
+  confirmButton: "Confirm",
+  checkAllButton: "Check All",
+  uncheckAllButton: "Uncheck All",
+  selectAtLeastOneError: "Please select at least one property to remove.",
+
+  // AddConfirmForm
+  ignoreMsg: "Any of these text props on existing notes will not be affected.",
+  appendMsg: "NOTE: Any pre-existing text props will have their values be appended to.",
+  overwriteMsg: "WARNING: Any pre-existing text props will have their values overwritten.",
+  followingPropsWillBeAdded: "The following props will be added:",
+  areYouSure: "Are you sure you wish to proceed?",
+  cancelButton: "Cancel",
+
+  // Status bar
+  addedPropsTo: "Added props to {count}/{total} files",
+  removedPropsFrom: "Removed props from {count}/{total} files",
+
+  // Common
+  pluginName: "Multi Properties",
+  addPropertiesTitle: "Add Properties",
+  removePropertiesTitle: "Remove Properties",
+  followingPropertiesWillBeRemoved: "The following {word} will be removed:",
+  property: "property",
+  properties: "properties",
+  deleteButton: "Delete",
+  pleaseCheckAtLeastOne: "Please check at least one property to remove."
+};

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,68 @@
+// i18n 入口文件
+import en from './en';
+import zh from './zh';
+
+type Translations = typeof en;
+
+export const translations: Record<string, Translations> = {
+  'en': en,
+  'zh': zh,
+  'en-US': en,
+  'en-GB': en,
+  'en-CA': en,
+  'en-AU': en,
+  'zh-CN': zh,
+  'zh-TW': zh,
+  'zh-HK': zh,
+  'zh-SG': zh
+};
+
+export function getTranslation(locale: string): Translations {
+  return translations[locale] || translations['en'];
+}
+
+export function detectLocale(): string {
+  // 首先尝试从 Obsidian 获取语言设置
+  try {
+    // @ts-ignore - Obsidian 内部 API
+    const obsidianLocale = window.localStorage?.getItem('language');
+    if (obsidianLocale && translations[obsidianLocale]) {
+      return obsidianLocale;
+    }
+    if (obsidianLocale) {
+      const shortLang = obsidianLocale.split('-')[0];
+      if (translations[shortLang]) {
+        return shortLang;
+      }
+    }
+  } catch (e) {
+    // 忽略错误，继续使用 navigator.language
+  }
+
+  // 然后使用 navigator.language
+  const navLang = navigator.language;
+
+  if (translations[navLang]) {
+    return navLang;
+  }
+
+  const shortLang = navLang.split('-')[0];
+  if (translations[shortLang]) {
+    return shortLang;
+  }
+
+  return 'en';
+}
+
+export function setLocale(locale: string) {
+  localStorage.setItem('multi-properties-locale', locale);
+}
+
+export function getStoredLocale(): string | null {
+  return localStorage.getItem('multi-properties-locale');
+}
+
+// 辅助函数：替换翻译字符串中的占位符
+export function format(template: string, params: Record<string, string | number>): string {
+  return template.replace(/{([^}]+)}/g, (_, key) => String(params[key] ?? ''));
+}

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -1,0 +1,89 @@
+// 中文翻译
+export default {
+  // Commands
+  addPropsToCurrentNote: "向当前笔记添加属性",
+  removePropsFromCurrentNote: "从当前笔记移除属性",
+  addPropsToTabGroup: "向活动标签组中的标签添加属性",
+  removePropsFromTabGroup: "从活动标签组中的标签移除属性",
+
+  // Menu items
+  addPropsToFile: "向文件添加属性",
+  addPropsToFolder: "向文件夹添加属性",
+  removePropsFromFile: "从文件移除属性",
+  removePropsFromFolder: "从文件夹移除属性",
+  addPropsFromAllTabs: "从所有标签添加属性",
+  removePropsFromAllTabs: "从所有标签移除属性",
+  addPropsToSelectedFiles: "向选中的文件添加属性",
+  removePropsFromSelectedFiles: "从选中的文件移除属性",
+  addPropsToSearchResults: "向搜索结果添加属性",
+  removePropsFromSearchResults: "从搜索结果移除属性",
+
+  // Notices
+  noActiveFileToAdd: "没有活动文件可添加属性。",
+  noActiveFileToRemove: "没有活动文件可移除属性。",
+  noOpenTabsToAdd: "活动标签组中没有打开的标签可添加属性。",
+  noOpenTabsToRemove: "活动标签组中没有打开的标签可移除属性。",
+  noFilesToAdd: "没有文件可添加属性。",
+  noFilesToRemove: "没有文件可移除属性。",
+  noPropertiesToRemove: "没有可移除的属性",
+  notValidPropsTemplate: "不是有效的属性模板。",
+  checkDefaultPropsPath: "请检查您在默认属性文件设置中输入的路径是否有效。",
+  delimiterMustBeSingleChar: "分隔符必须是单个字符。",
+
+  // Settings
+  settingsTitle: "Multi Properties 设置",
+  alterPropName: "如何处理已存在的属性？",
+  alterPropDesc: "确定当文件中已存在同名属性时应如何处理。注意，不兼容的类型无法追加（如向日期添加数字）。",
+  overwriteProp: "覆盖属性",
+  appendToProp: "追加到属性",
+  ignoreProp: "忽略属性",
+  recursiveName: "递归迭代",
+  recursiveDesc: "启用后，在遍历文件夹中的所有文件时，也将遍历任何子文件夹。",
+  listDelimiterName: "列表分隔符",
+  listDelimiterDesc: "设置创建列表时使用的分隔符，默认使用逗号(,)。",
+  defaultPropsFileName: "默认属性文件",
+  defaultPropsFileDesc: "选择一个包含属性的文件，您希望默认加载到 Multi Properties 表单中。输入所需文件的完整路径（例如 Templates/PropFile 1）。",
+
+  // AddPropForm
+  selectFromExistingOrCreate: "从现有属性中选择或创建新属性：",
+  typePropertyNameAndValue: "输入属性名称，然后输入值。使用下拉框选择您要存储的数据类型。",
+  makeListPropertyNote: "如果要创建列表属性，请使用文本数据类型，并用 \"{delimiter}\" 分隔每个值。",
+  addTagsNote: "如果要添加标签，请使用名称 \"tags\"。",
+  howToAlterPropsLabel: "如何处理笔记中已存在的属性。",
+  ignoreOption: "完全忽略该属性。",
+  overwriteOption: "用新值覆盖属性。",
+  appendOption: "向属性追加新值。",
+  addButton: "添加",
+  submitButton: "提交",
+  duplicateNamesError: "不允许重复的属性名称。",
+  errorLabel: "错误",
+
+  // RemovePropForm
+  selectPropertiesToRemove: "选择您希望从文件选择中移除的属性。",
+  confirmButton: "确认",
+  checkAllButton: "全选",
+  uncheckAllButton: "取消全选",
+  selectAtLeastOneError: "请至少选择一个要移除的属性。",
+
+  // AddConfirmForm
+  ignoreMsg: "现有笔记上的这些文本属性不会受到影响。",
+  appendMsg: "注意：任何已存在的文本属性的值将被追加。",
+  overwriteMsg: "警告：任何已存在的文本属性的值将被覆盖。",
+  followingPropsWillBeAdded: "将添加以下属性：",
+  areYouSure: "您确定要继续吗？",
+  cancelButton: "取消",
+
+  // Status bar
+  addedPropsTo: "已向 {count}/{total} 个文件添加属性",
+  removedPropsFrom: "已从 {count}/{total} 个文件移除属性",
+
+  // Common
+  pluginName: "Multi Properties",
+  addPropertiesTitle: "添加属性",
+  removePropertiesTitle: "移除属性",
+  followingPropertiesWillBeRemoved: "将移除以下{word}：",
+  property: "个属性",
+  properties: "个属性",
+  deleteButton: "删除",
+  pleaseCheckAtLeastOne: "请至少选择一个要移除的属性。"
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,8 @@ import { type MultiPropSettings, SettingTab } from "./SettingTab";
 import { RemoveModal } from "./RemoveModal";
 import { addProperties, addPropToSet, removeProperties } from "./frontmatter";
 import type { Property, PropertyTypes } from "./types/custom";
+import { getTranslation, detectLocale, getStoredLocale, format } from "./i18n";
+import type en from "./i18n/en";
 
 const defaultSettings: MultiPropSettings = {
   alterProp: "ignore",
@@ -30,6 +32,9 @@ export interface NewPropData {
 
 export default class MultiPropPlugin extends Plugin {
   settings: MultiPropSettings;
+  t: typeof en;
+  currentLocale: string;
+
   async loadSettings() {
     this.settings = Object.assign({}, defaultSettings, await this.loadData());
   }
@@ -41,6 +46,12 @@ export default class MultiPropPlugin extends Plugin {
   async changeAlterProp(value: MultiPropSettings["alterProp"]) {
     this.settings.alterProp = value;
     await this.saveSettings();
+  }
+
+  initI18n() {
+    const storedLocale = getStoredLocale();
+    this.currentLocale = storedLocale || detectLocale();
+    this.t = getTranslation(this.currentLocale);
   }
 
   private _getFilesFromTabGroup(leaf: WorkspaceLeaf | null): TFile[] {
@@ -81,16 +92,17 @@ export default class MultiPropPlugin extends Plugin {
 
   async onload() {
     await this.loadSettings();
+    this.initI18n();
     this.addSettingTab(new SettingTab(this.app, this));
 
     // All commands for single notes & folders.
     this.addCommand({
       id: "add-props-to-current-note",
-      name: "Add props to current note",
+      name: this.t.addPropsToCurrentNote,
       callback: async () => {
         const file = this.app.workspace.getActiveFile();
         if (!file) {
-          new Notice("No active file to add properties to.", 4000);
+          new Notice(this.t.noActiveFileToAdd, 4000);
           return;
         }
         await this.createPropModal([file]);
@@ -104,10 +116,10 @@ export default class MultiPropPlugin extends Plugin {
 
         if (node instanceof TFile) {
           obj = [node];
-          title = "Add props to file.";
+          title = this.t.addPropsToFile;
         } else {
           obj = node as TFolder;
-          title = "Add props to folder.";
+          title = this.t.addPropsToFolder;
         }
 
         menu.addItem((item) => {
@@ -121,11 +133,11 @@ export default class MultiPropPlugin extends Plugin {
 
     this.addCommand({
       id: "remove-props-from-current-note",
-      name: "Remove props from current note",
+      name: this.t.removePropsFromCurrentNote,
       callback: async () => {
         const file = this.app.workspace.getActiveFile();
         if (!file) {
-          new Notice("No active file to remove properties from.", 4000);
+          new Notice(this.t.noActiveFileToRemove, 4000);
           return;
         }
         await this.createRemoveModal([file]);
@@ -139,10 +151,10 @@ export default class MultiPropPlugin extends Plugin {
 
         if (node instanceof TFile) {
           obj = [node];
-          title = "Remove props from file.";
+          title = this.t.removePropsFromFile;
         } else {
           obj = node as TFolder;
-          title = "Remove props from folder.";
+          title = this.t.removePropsFromFolder;
         }
 
         menu.addItem((item) => {
@@ -157,12 +169,12 @@ export default class MultiPropPlugin extends Plugin {
     //All commands for affecting props in all tabs.
     this.addCommand({
       id: "add-props-to-tab-group",
-      name: "Add props to tabs in active tab group",
+      name: this.t.addPropsToTabGroup,
       callback: async () => {
         const files = this._getFilesFromTabGroup(this.app.workspace.activeLeaf);
         if (!files || !files.length) {
           new Notice(
-            "No open tabs in the active tab group to add properties to.",
+            this.t.noOpenTabsToAdd,
             4000
           );
           return;
@@ -179,7 +191,7 @@ export default class MultiPropPlugin extends Plugin {
         menu.addItem((item) => {
           item
             .setIcon("archive")
-            .setTitle("Add props from all tabs")
+            .setTitle(this.t.addPropsFromAllTabs)
             .onClick(() => this.createPropModal(obj));
         });
       })
@@ -187,14 +199,14 @@ export default class MultiPropPlugin extends Plugin {
 
     this.addCommand({
       id: "remove-props-from-tab-group",
-      name: "Remove props from tabs in active tab group",
+      name: this.t.removePropsFromTabGroup,
       callback: async () => {
         const files = this._getFilesFromTabGroup(
           this.app.workspace.getLeaf(false)
         );
         if (!files || !files.length) {
           new Notice(
-            "No open tabs in the active tab group to remove properties from.",
+            this.t.noOpenTabsToRemove,
             4000
           );
           return;
@@ -211,7 +223,7 @@ export default class MultiPropPlugin extends Plugin {
         menu.addItem((item) => {
           item
             .setIcon("archive")
-            .setTitle("Remove props from all tabs")
+            .setTitle(this.t.removePropsFromAllTabs)
             .onClick(() => this.createRemoveModal(obj));
         });
       })
@@ -226,7 +238,7 @@ export default class MultiPropPlugin extends Plugin {
         menu.addItem((item) => {
           item
             .setIcon("archive")
-            .setTitle("Add props to selected files")
+            .setTitle(this.t.addPropsToSelectedFiles)
             .onClick(() => this.createPropModal(obj));
         });
       })
@@ -238,7 +250,7 @@ export default class MultiPropPlugin extends Plugin {
         menu.addItem((item) => {
           item
             .setIcon("archive")
-            .setTitle("Remove props from selected files")
+            .setTitle(this.t.removePropsFromSelectedFiles)
             .onClick(async () => this.createRemoveModal(obj));
         });
       })
@@ -249,11 +261,11 @@ export default class MultiPropPlugin extends Plugin {
         menu.addItem((item) => {
           item
             .setIcon("archive")
-            .setTitle("Add props to search results")
+            .setTitle(this.t.addPropsToSearchResults)
             .onClick(() => {
               let files = this.getFilesFromSearch(leaf);
               if (!files.length) {
-                new Notice("No files to add properties to.", 4000);
+                new Notice(this.t.noFilesToAdd, 4000);
                 return;
               }
               this.createPropModal(files);
@@ -267,11 +279,11 @@ export default class MultiPropPlugin extends Plugin {
         menu.addItem((item) => {
           item
             .setIcon("archive")
-            .setTitle("Remove props from search results")
+            .setTitle(this.t.removePropsFromSearchResults)
             .onClick(async () => {
               let files = this.getFilesFromSearch(leaf);
               if (!files.length) {
-                new Notice("No files to remove properties from.", 4000);
+                new Notice(this.t.noFilesToRemove, 4000);
                 return;
               }
               this.createRemoveModal(files);
@@ -374,7 +386,8 @@ export default class MultiPropPlugin extends Plugin {
       this.settings.delimiter,
       defaultProps,
       this.changeAlterProp.bind(this),
-      allProps
+      allProps,
+      this.t
     ).open();
   }
 
@@ -401,7 +414,7 @@ export default class MultiPropPlugin extends Plugin {
       );
 
     if (names.length === 0) {
-      new Notice("No properties to remove", 4000);
+      new Notice(this.t.noPropertiesToRemove, 4000);
       return;
     }
 
@@ -409,7 +422,7 @@ export default class MultiPropPlugin extends Plugin {
       a.toLowerCase() > b.toLowerCase() ? 1 : -1
     );
 
-    new RemoveModal(this.app, sortedNames, iterateFunc).open();
+    new RemoveModal(this.app, sortedNames, iterateFunc, this.t).open();
   }
 
   /** Read through a given file and get name/value of props.
@@ -420,7 +433,7 @@ export default class MultiPropPlugin extends Plugin {
     const frontmatter = metadata?.frontmatter;
 
     if (!frontmatter) {
-      new Notice("Not a valid Props template.", 4000);
+      new Notice(this.t.notValidPropsTemplate, 4000);
       return;
     }
 
@@ -452,7 +465,7 @@ export default class MultiPropPlugin extends Plugin {
         return tmp;
       } catch (e) {
         new Notice(
-          `${e}.  Check if you entered a valid path in the Default Props File setting.`,
+          `${e}.  ${this.t.checkDefaultPropsPath}`,
           10000
         );
       }
@@ -475,7 +488,7 @@ export default class MultiPropPlugin extends Plugin {
 
       count++;
       statusBarItem.setText(
-        "Added props to " + count + "/" + totalFiles + " files"
+        format(this.t.addedPropsTo, { count, total: totalFiles })
       );
 
       if (count === totalFiles) {
@@ -499,7 +512,7 @@ export default class MultiPropPlugin extends Plugin {
 
       count++;
       statusBarItem.setText(
-        "Removed props from " + count + "/" + totalFiles + " files"
+        format(this.t.removedPropsFrom, { count, total: totalFiles })
       );
 
       if (count === totalFiles) {


### PR DESCRIPTION
- Create an i18n module that includes English and Chinese translation files.
- Implement automatic language detection, prioritizing the Obsidian settings and then the browser language.
- Modify the main plugin file, settings tab, modal box, and all Svelte components to use translations.
- Add a translation string formatting function that supports dynamic text with parameters.
- Update the package versions of dependencies to maintain compatibility.